### PR TITLE
invert array_intersect args order in parse_groupby

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1447,7 +1447,7 @@ class Query extends Base {
 		$columns   = array_flip( $this->get_column_names() );
 
 		// Get the intersection of allowed column names to groupby columns
-		$intersect = array_intersect( $columns, $groupby );
+		$intersect = array_intersect( $groupby, $columns );
 
 		// Bail if invalid column
 		if ( empty( $intersect ) ) {


### PR DESCRIPTION
This is to preserve groupby columns order as specified by the caller, which is currenty reset to default columns order defined in relevant schema.